### PR TITLE
chore: release v0.1.0

### DIFF
--- a/rp_sandbox_a/CHANGELOG.md
+++ b/rp_sandbox_a/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_a-v0.1.0)
+_05 September 2024_
+
+### Other
+* nvm Didn't need the 0.0.1 nonsense
+* Maybe the names were too generic?

--- a/rp_sandbox_b/CHANGELOG.md
+++ b/rp_sandbox_b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_b-v0.1.0)
+_05 September 2024_
+
+### Other
+* nvm Didn't need the 0.0.1 nonsense
+* Maybe the names were too generic?

--- a/rp_sandbox_c/CHANGELOG.md
+++ b/rp_sandbox_c/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_c-v0.1.0)
+_05 September 2024_
+
+### Other
+* nvm Didn't need the 0.0.1 nonsense
+* Maybe the names were too generic?


### PR DESCRIPTION
## 🤖 New release
* `rp_sandbox_a`: 0.1.0
* `rp_sandbox_b`: 0.1.0
* `rp_sandbox_c`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `rp_sandbox_a`
<blockquote>

## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_a-v0.1.0)

_05 September 2024_

### Other
* nvm Didn't need the 0.0.1 nonsense
* Maybe the names were too generic?
</blockquote>

## `rp_sandbox_b`
<blockquote>

## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_b-v0.1.0)

_05 September 2024_

### Other
* nvm Didn't need the 0.0.1 nonsense
* Maybe the names were too generic?
</blockquote>

## `rp_sandbox_c`
<blockquote>

## [0.1.0](https://github.com/scouten-adobe/rp-sandbox/releases/tag/rp_sandbox_c-v0.1.0)

_05 September 2024_

### Other
* nvm Didn't need the 0.0.1 nonsense
* Maybe the names were too generic?
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).