### PR TITLE
chore: release v0.3.0

### DIFF
--- a/rp_sandbox_a/CHANGELOG.md
+++ b/rp_sandbox_a/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.2.0...rp_sandbox_a-v0.3.0)
+_01 October 2024_
+
+### Added
+* Remove fn add3
+
 ## [0.2.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.1.0...rp_sandbox_a-v0.2.0)
 _06 September 2024_
 

--- a/rp_sandbox_a/Cargo.toml
+++ b/rp_sandbox_a/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp_sandbox_a"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/rp_sandbox_b/CHANGELOG.md
+++ b/rp_sandbox_b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.2.0...rp_sandbox_b-v0.3.0)
+_01 October 2024_
+
+### Added
+* Add `fn add9`
+
 ## [0.2.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.1.0...rp_sandbox_b-v0.2.0)
 _06 September 2024_
 

--- a/rp_sandbox_b/Cargo.toml
+++ b/rp_sandbox_b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "rp_sandbox_b"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.2.0" }
+rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.3.0" }


### PR DESCRIPTION
## 🤖 New release
* `rp_sandbox_a`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `rp_sandbox_b`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

### ⚠️ `rp_sandbox_a` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/function_missing.ron

Failed in:
  function rp_sandbox_a::add3, previously in file /tmp/.tmp0gyand/rp_sandbox_a/src/lib.rs:5
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rp_sandbox_a`
<blockquote>

## [0.3.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.2.0...rp_sandbox_a-v0.3.0)

_01 October 2024_

### Added
* Remove fn add3
</blockquote>

## `rp_sandbox_b`
<blockquote>

## [0.3.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.2.0...rp_sandbox_b-v0.3.0)

_01 October 2024_

### Added
* Add `fn add9`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).