### PR TITLE
chore: release v0.12.0

### DIFF
--- a/rp_sandbox_a/CHANGELOG.md
+++ b/rp_sandbox_a/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.11.0...rp_sandbox_a-v0.12.0)
+_08 July 2025_
+
+### Fixed
+
+* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
+
 ## [0.11.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.10.0...rp_sandbox_a-v0.11.0)
 _07 July 2025_
 

--- a/rp_sandbox_a/Cargo.toml
+++ b/rp_sandbox_a/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp_sandbox_a"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/rp_sandbox_b/CHANGELOG.md
+++ b/rp_sandbox_b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.11.0...rp_sandbox_b-v0.12.0)
+_08 July 2025_
+
+### Added
+
+* Remove `test_add_more_magic` ([#53](https://github.com/scouten-adobe/rp-sandbox/pull/53))
+
+### Fixed
+
+* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
+
 ## [0.3.2](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.3.1...rp_sandbox_b-v0.3.2)
 _03 December 2024_
 

--- a/rp_sandbox_b/Cargo.toml
+++ b/rp_sandbox_b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "rp_sandbox_b"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]
-rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.11.0" }
+rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.12.0" }

--- a/rp_sandbox_c/CHANGELOG.md
+++ b/rp_sandbox_c/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_c-v0.11.0...rp_sandbox_c-v0.12.0)
+_08 July 2025_
+
+### Fixed
+
+* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
+
 ## [0.1.1](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_c-v0.1.0...rp_sandbox_c-v0.1.1)
 _06 September 2024_
 

--- a/rp_sandbox_c/Cargo.toml
+++ b/rp_sandbox_c/Cargo.toml
@@ -2,8 +2,8 @@
 name = "rp_sandbox_c"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]
-rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.11.0" }
+rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.12.0" }


### PR DESCRIPTION



## 🤖 New release

* `rp_sandbox_a`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `rp_sandbox_b`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `rp_sandbox_c`: 0.11.0 -> 0.12.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rp_sandbox_a`

<blockquote>

## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.11.0...rp_sandbox_a-v0.12.0)

_08 July 2025_

### Fixed

* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
</blockquote>

## `rp_sandbox_b`

<blockquote>

## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.11.0...rp_sandbox_b-v0.12.0)

_08 July 2025_

### Added

* Remove `test_add_more_magic` ([#53](https://github.com/scouten-adobe/rp-sandbox/pull/53))

### Fixed

* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
</blockquote>

## `rp_sandbox_c`

<blockquote>

## [0.12.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_c-v0.11.0...rp_sandbox_c-v0.12.0)

_08 July 2025_

### Fixed

* Try using version groups ([#54](https://github.com/scouten-adobe/rp-sandbox/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).