### PR TITLE
feat: See if version groups work for this situation

### DIFF
--- a/rp_sandbox_b/src/lib.rs
+++ b/rp_sandbox_b/src/lib.rs
@@ -37,4 +37,10 @@ mod tests {
         let result = add9(1);
         assert_eq!(result, 10);
     }
+
+    #[test]
+    fn test_add_more_magic() {
+        let result = add_more_magic(7);
+        assert_eq!(result, 62);
+    }
 }


### PR DESCRIPTION
Theory: rp_sandbox_b will advance to 0.13.0 and will gain a dependency on rp_sandbox_a version 0.13.0, which won't be published because there aren't any changes to that crate's source since 0.12.0.

Theory: This will make rp_sandbox_b fail unpublishable.