### PR TITLE
chore: release v0.15.0

### DIFF
--- a/rp_sandbox_a/CHANGELOG.md
+++ b/rp_sandbox_a/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.14.0...rp_sandbox_a-v0.15.0)
+_09 July 2025_
+
+### Added
+
+* Redefine "magic number" ([#52](https://github.com/scouten-adobe/rp-sandbox/pull/52))
+
 ## [0.14.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.13.0...rp_sandbox_a-v0.14.0)
 _09 July 2025_
 

--- a/rp_sandbox_a/Cargo.toml
+++ b/rp_sandbox_a/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp_sandbox_a"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]

--- a/rp_sandbox_b/CHANGELOG.md
+++ b/rp_sandbox_b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.14.0...rp_sandbox_b-v0.15.0)
+_09 July 2025_
+
+### Added
+
+* Redefine "magic number" ([#52](https://github.com/scouten-adobe/rp-sandbox/pull/52))
+
 ## [0.14.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.13.0...rp_sandbox_b-v0.14.0)
 _09 July 2025_
 

--- a/rp_sandbox_b/Cargo.toml
+++ b/rp_sandbox_b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "rp_sandbox_b"
 description = "Testing project -- please ignore"
 license = "MIT OR Apache-2.0"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [dependencies]
-rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.14.0" }
+rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.15.0" }

--- a/rp_sandbox_c/Cargo.toml
+++ b/rp_sandbox_c/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.12.0"
 edition = "2021"
 
 [dependencies]
-rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.14.0" }
+rp_sandbox_a = { path = "../rp_sandbox_a", version = "0.15.0" }


### PR DESCRIPTION



## 🤖 New release

* `rp_sandbox_a`: 0.14.0 -> 0.15.0 (✓ API compatible changes)
* `rp_sandbox_b`: 0.14.0 -> 0.15.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rp_sandbox_a`

<blockquote>

## [0.15.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_a-v0.14.0...rp_sandbox_a-v0.15.0)

_09 July 2025_

### Added

* Redefine "magic number" ([#52](https://github.com/scouten-adobe/rp-sandbox/pull/52))
</blockquote>

## `rp_sandbox_b`

<blockquote>

## [0.15.0](https://github.com/scouten-adobe/rp-sandbox/compare/rp_sandbox_b-v0.14.0...rp_sandbox_b-v0.15.0)

_09 July 2025_

### Added

* Redefine "magic number" ([#52](https://github.com/scouten-adobe/rp-sandbox/pull/52))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).